### PR TITLE
Changing a remote's URL

### DIFF
--- a/data/git.json
+++ b/data/git.json
@@ -243,7 +243,7 @@
         },
         {
           "definition": "রিমোটের URL পরিবর্তন করা",
-          "code": "git remote set-url origin RemoteURL"
+          "code": "git remote set-url origin <RemoteURL>"
         },
         {
           "definition": "অন্য Repository থেকে ব্রাঞ্চ/রেফ/অবজেক্ট fetch করা",

--- a/data/git.json
+++ b/data/git.json
@@ -242,6 +242,10 @@
           "code": "git remote -v"
         },
         {
+          "definition": "রিমোটের URL পরিবর্তন করা",
+          "code": "git remote set-url origin RemoteURL"
+        },
+        {
           "definition": "অন্য Repository থেকে ব্রাঞ্চ/রেফ/অবজেক্ট fetch করা",
           "code": "git fetch RepositoryName"
         },


### PR DESCRIPTION
The **git remote set-url  command changes an existing remote repository URL.