### PR TITLE
ভুল কমান্ড মুছে ফেলা হয়েছে

### DIFF
--- a/data/laravel-framework.json
+++ b/data/laravel-framework.json
@@ -43,9 +43,6 @@
                 "definition": "একটি নির্ধারিত নেমস্পেস ক্রিয়েট করা",
                 "code": "php artisan app:name devsonket"
             }, {
-                "definition": "লারাভেলে এইচটিএমএল প্যাকেজ যুক্ত করা",
-                "code": "php artisan composer require illuminate/html"
-            }, {
                 "definition": "লারাভেলে ইভেন্ট জেনারেট করা",
                 "code": "php artisan event:generate"
             }, {


### PR DESCRIPTION
`php artisan composer require illuminate/html`  এই কমান্ডটি সঠিক না তবে কমান্ডটি `composer require illuminate/html` এমন হওয়া উচিৎ। যেহেতু এই প্যাকেজটা শুধুমাত্র লারাভেল ৫ এর জন্য তাই এইটা এখানে না রাখাকে উত্তম বলে মনে করছি।

কি বলেন?