### PR TITLE
Shortcut windows 10

### DIFF
--- a/data/shortcut-win10.json
+++ b/data/shortcut-win10.json
@@ -53,6 +53,10 @@
                 {
                     "definition": "টাস্ক ম্যানেজার ওপেন করা",
                     "code": "Ctrl + Alt + Del"
+                },
+                {
+                    "definition": "টাস্কগুলোর মধ্যে সুইচ করা",
+                    "code": "Alt + Tab"
                 }
             ]
         },


### PR DESCRIPTION
Added a new Shortcut in Windows 10 OS cheatsheet. The shortcut is Task Switcher: Alt + Tab