### PR TITLE
Added GCC Command Cheat Sheet

### DIFF
--- a/data/gcc-compiler.json
+++ b/data/gcc-compiler.json
@@ -1,0 +1,51 @@
+{
+    "id": "gcc_commands",
+    "title": "GCC (MinGW/Cygwin/UNIX) কমান্ডের চিটশিট",
+    "slug": "gcc_commands",
+    "description": "GCC হল একটি ফ্রি এবং ওপেন সোর্স কম্পাইলার যা C, C++, Objective-C, Fortran, Go, Rust, D, Pascal, RISC-V ইত্যাদি Laguage গুলিকে Compile করে।",
+    "colorPref": "#FFC0CB",
+    "contents": [
+        {
+            "title": "Common Commands",
+            "items": [
+                {
+                    "definition": "-o: আউটপুট ফাইলের নাম নির্ধারণ করে।",
+                    "code": "gcc -o output_file source_file.c"
+                },
+                {
+                    "definition": "-c: শুধুমাত্র Source কোডকে অবজেক্ট কোডে কম্পাইল করে।",
+                    "code": "gcc -c source_file.c"
+                },
+                {
+                    "definition": "-S: শুধুমাত্র Source কোডকে অ্যাসেম্বলি কোডে কম্পাইল করে।",
+                    "code": "gcc -S source_file.c"
+                },
+                {
+                    "definition": "-g: ডিবাগ তথ্য Include করে।",
+                    "code": "gcc -g source_file.c"
+                },
+                {
+                    "definition": "-Wall: Compiler warning গুলিকে Enable করে।",
+                    "code": "gcc -Wall source_file.c"
+                }
+            ]
+        },
+        {
+            "title": "Specific Commands",
+            "items": [
+                {
+                    "definition": "-ansi: ANSI C মান মেনে চলতে কম্পাইলারকে বাধ্য করে।",
+                    "code": "gcc -ansi source_file.c"
+                },
+                {
+                    "definition": "-pedantic: ANSI C মান মেনে চলতে কম্পাইলারকে Enforce করে।",
+                    "code": "gcc -pedantic source_file.c"
+                },
+                {
+                    "definition": "-Werror: Warning গুলিকে Error হিসাবে চিহ্নিত করে।",
+                    "code": "gcc -Werror source_file.c"
+                }
+            ]
+        }
+    ]
+}

--- a/data/microsoft-office.json
+++ b/data/microsoft-office.json
@@ -1,0 +1,96 @@
+{
+    "id": "microsoft_office",
+    "title": "মাইক্রোসফট অফিস(ওয়ার্ড, পাওয়ারপয়েন্ট ইত্যাদির শর্টকাট কী)",
+    "slug": "microsoft_office",
+    "description": "কোড এবং বর্ণনা সমৃদ্ধ চিটশিট এর ডিমো",
+    "colorPref": "#000",
+    "contents": [
+        {
+            "title": "ওয়ার্ড শর্টকাট কী",
+            "items": [
+                {
+                    "definition": "মানুষের মন্তব্যকে কপি করতে",
+                    "code": "Ctrl + C"
+                },
+                {
+                    "definition": "নির্দিষ্ট সেলেক্ট করে কপি করতে",
+                    "code": "Ctrl + C"
+                },
+                {
+                    "definition": "সাধারণ টেক্সট সিলেক্ট করে কপি করতে",
+                    "code": "Ctrl + C"
+                },
+                {
+                    "definition": "কপি করা টেক্সট পেস্ট করতে",
+                    "code": "Ctrl + V"
+                },
+                {
+                    "definition": "নতুন ওয়ার্ড ডকুমেন্ট তৈরি করতে",
+                    "code": "Ctrl + N"
+                },
+                {
+                    "definition": "ডকুমেন্ট খোলতে",
+                    "code": "Ctrl + O"
+                },
+                {
+                    "definition": "ডকুমেন্ট সংরক্ষণ করতে",
+                    "code": "Ctrl + S"
+                }
+            ]
+        },
+        {
+            "title": "পাওয়ারপয়েন্ট শর্টকাট কী",
+            "items": [
+                {
+                    "definition": "নতুন পাওয়ারপয়েন্ট প্রেজেন্টেশন তৈরি করতে",
+                    "code": "Ctrl + N"
+                },
+                {
+                    "definition": "প্রেজেন্টেশন সংরক্ষণ করতে",
+                    "code": "Ctrl + S"
+                },
+                {
+                    "definition": "পাওয়ারপয়েন্টে নতুন স্লাইড তৈরি করতে",
+                    "code": "Ctrl + M"
+                },
+                {
+                    "definition": "পাওয়ারপয়েন্টে প্রেজেন্টেশন শুরু করতে",
+                    "code": "F5"
+                },
+                {
+                    "definition": "স্লাইড প্রস্তুত করতে",
+                    "code": "Ctrl + D"
+                },
+                {
+                    "definition": "প্রেজেন্টেশন মোড থেকে বের হতে",
+                    "code": "Esc"
+                }
+            ]
+        },
+        {
+            "title": "এক্সেল শর্টকাট কী",
+            "items": [
+                {
+                    "definition": "সেলেক্টেড সেলেক্ট করতে",
+                    "code": "Shift + Spacebar"
+                },
+                {
+                    "definition": "সম্পূর্ণ কলাম সেলেক্ট করতে",
+                    "code": "Ctrl + Spacebar"
+                },
+                {
+                    "definition": "সম্পূর্ণ সারি সেলেক্ট করতে",
+                    "code": "Shift + Spacebar"
+                },
+                {
+                    "definition": "সেলেক্টেড সেলেক্ট করতে",
+                    "code": "Ctrl + A"
+                },
+                {
+                    "definition": "ফরমুলা এডিট করতে",
+                    "code": "F2"
+                }
+            ]
+        }
+    ]
+}

--- a/data/microsoft-office.json
+++ b/data/microsoft-office.json
@@ -6,18 +6,10 @@
     "colorPref": "#000",
     "contents": [
         {
-            "title": "ওয়ার্ড শর্টকাট কী",
+            "title": "Microsoft Word শর্টকাট কী",
             "items": [
                 {
-                    "definition": "মানুষের মন্তব্যকে কপি করতে",
-                    "code": "Ctrl + C"
-                },
-                {
-                    "definition": "নির্দিষ্ট সেলেক্ট করে কপি করতে",
-                    "code": "Ctrl + C"
-                },
-                {
-                    "definition": "সাধারণ টেক্সট সিলেক্ট করে কপি করতে",
+                    "definition": "Text কপি করতে",
                     "code": "Ctrl + C"
                 },
                 {
@@ -33,20 +25,32 @@
                     "code": "Ctrl + O"
                 },
                 {
-                    "definition": "ডকুমেন্ট সংরক্ষণ করতে",
+                    "definition": "ডকুমেন্ট Save করতে",
                     "code": "Ctrl + S"
+                },
+                {
+                    "definition": "টেক্সট ফরম্যাট করতে",
+                    "code": "Ctrl + Shift + F"
+                },
+                {
+                    "definition": "টেবিল তৈরি করতে",
+                    "code": "Ctrl + T"
+                },
+                {
+                    "definition": "শর্টকাট কীগুলি দেখতে",
+                    "code": "Alt + F1"
                 }
             ]
         },
         {
-            "title": "পাওয়ারপয়েন্ট শর্টকাট কী",
+            "title": "Microsoft PowerPoint শর্টকাট কী",
             "items": [
                 {
                     "definition": "নতুন পাওয়ারপয়েন্ট প্রেজেন্টেশন তৈরি করতে",
                     "code": "Ctrl + N"
                 },
                 {
-                    "definition": "প্রেজেন্টেশন সংরক্ষণ করতে",
+                    "definition": "প্রেজেন্টেশন Save করতে",
                     "code": "Ctrl + S"
                 },
                 {
@@ -62,29 +66,37 @@
                     "code": "Ctrl + D"
                 },
                 {
+                    "definition": "অ্যানিমেশন যোগ করতে",
+                    "code": "Ctrl + Shift + W"
+                },
+                {
                     "definition": "প্রেজেন্টেশন মোড থেকে বের হতে",
                     "code": "Esc"
                 }
             ]
         },
         {
-            "title": "এক্সেল শর্টকাট কী",
+            "title": "Microsoft Excel শর্টকাট কী",
             "items": [
                 {
-                    "definition": "সেলেক্টেড সেলেক্ট করতে",
-                    "code": "Shift + Spacebar"
+                    "definition": "নতুন এক্সেল স্প্রেডশিট তৈরি করতে",
+                    "code": "Ctrl + N"
                 },
                 {
                     "definition": "সম্পূর্ণ কলাম সেলেক্ট করতে",
                     "code": "Ctrl + Spacebar"
                 },
                 {
-                    "definition": "সম্পূর্ণ সারি সেলেক্ট করতে",
-                    "code": "Shift + Spacebar"
+                    "definition": "গ্রাফ তৈরি করতে",
+                    "code": "Ctrl + F1"
                 },
                 {
-                    "definition": "সেলেক্টেড সেলেক্ট করতে",
-                    "code": "Ctrl + A"
+                    "definition": "পূর্ববর্তী সেলে যান",
+                    "code": "Ctrl + PgUp"
+                },
+                {
+                    "definition": "পরবর্তী সেলে যান",
+                    "code": "Ctrl + PgDn"
                 },
                 {
                     "definition": "ফরমুলা এডিট করতে",


### PR DESCRIPTION
This pull request introduces a new GCC Command Cheat Sheet to the documentation. The cheat sheet offers valuable insights into common GCC commands, focusing on MinGW, Cygwin, and UNIX environments. Each command comes with a concise description, making it easier for users to understand and utilize these commands effectively. This addition aims to enhance user proficiency with GCC commands when working on C and C++ projects.

Please review and merge this pull request to incorporate the updated documentation into the project.