### PR TITLE
feat: smooth scroll behavior using css only

### DIFF
--- a/src/components/layout/app.css
+++ b/src/components/layout/app.css
@@ -12,6 +12,8 @@
 html {
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
+  scroll-behavior: smooth;
+  scroll-padding-top: 1em;
 }
 
 body {


### PR DESCRIPTION
### What does this feature do?
- when we visit a cheatsheet page, we can click on title link of a topic
- and the browser will smoothly scroll to the target section instead of instantly jumping to it(default behavior)
- moreover, when we share a cheatsheet link with a specific section, this will also smoothly scroll to that section