### PR TITLE
chore: Update deprecated substr() to substring()

### DIFF
--- a/src/components/common/Card.js
+++ b/src/components/common/Card.js
@@ -42,7 +42,7 @@ export const Card = ({ id, title, description, colorPref }) => (
         <>
           <p>
             {String(description)
-              .substr(0, 33)
+              .substring(0, 33)
               .trim()}
             ...
           </p>


### PR DESCRIPTION
this pr updates the usage of the deprecated substr() method to the recommended substring() method in order to improve code maintainability and compatibility.

source(mdn): https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr