### PR TITLE
fix: updated docker stop command

### DIFF
--- a/data/docker.json
+++ b/data/docker.json
@@ -75,6 +75,10 @@
                 },
                 {
                     "definition": "সব ডকার কন্টেইনার stop করতে",
+                    "code": "docker stop $(docker ps -q)"
+                },
+                {
+                    "definition": "সব ডকার কন্টেইনার kill করতে",
                     "code": "docker kill $(docker ps -q)"
                 },
                 {


### PR DESCRIPTION
This update replaces the kill command with a safer alternative for stopping Docker containers. The previous approach terminated containers immediately, which could lead to data loss or corruption. The new implementation uses the stop command to allow for a more graceful shutdown.