### PR TITLE
feat: add new docker container exec command

### DIFF
--- a/data/docker.json
+++ b/data/docker.json
@@ -154,7 +154,11 @@
                 },
                 {
                     "definition": "নির্দিষ্ট কন্টেইনারে প্রবেশ করতে",
-                    "code": "docker-compose exec container /bin/bash"
+                    "code": "docker-compose exec <container_id> /bin/bash"
+                },
+                {
+                    "definition": "নির্দিষ্ট কন্টেইনারে যে কোন কমান্ড রান করতে",
+                    "code": "docker-compose exec -it <container_id> <command>"
                 },
                 {
                     "definition": "নেটওয়ার্ক সহ কন্টেইনার remove করতে",


### PR DESCRIPTION
This PR corrects the usage of docker-compose exec by replacing the placeholder `container` with `<container_id>` for clarity.

Additionally, it introduces new code that allows running any command within a specified Docker container.