### PR TITLE
fix: use manage.py instead of django-admin to create app

### DIFF
--- a/data/django.json
+++ b/data/django.json
@@ -162,7 +162,7 @@
             "items": [
                 {
                     "definition": "অ্যাপ তৈরী করা",
-                    "code": "django-admin startapp <app_name>"
+                    "code": "python manage.py startapp <app_name>"
                 },
                 {
                     "definition": "প্রোজেক্ট এর settings.py ফাইলে অ্যাাপ ইনস্টল করার জন্য",


### PR DESCRIPTION
We should use `python manage.py startapp` to create an app because it helps django recognize the app in INSTALLED_APPS. This is the best practice!